### PR TITLE
Fix all the Typescript errors that arise from running 'npm run build'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-#      - name: Run TypeScript build
-#        run: npm run build
-#
-#      - name: Run tests
-#        run: npm test
+      - name: Run TypeScript build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/src/main/ts/booklet/impure/Main.ts
+++ b/src/main/ts/booklet/impure/Main.ts
@@ -1,4 +1,5 @@
-import { Config, ConfigLive } from './Config';
+import { Config } from './Config';
+import { ConfigLive } from './ConfigLive';
 import { BookRouter } from './router/BookRouter';
 import { ReadingRouter } from './router/ReadingRouter';
 import { RootRouter } from './router/RootRouter';

--- a/src/main/ts/booklet/impure/router/BookFinderRouter.ts
+++ b/src/main/ts/booklet/impure/router/BookFinderRouter.ts
@@ -1,4 +1,4 @@
-import { Http, Request, Response } from 'some-http-library';
+import { Http, Request, Response } from 'zhttp/http';
 import { GoogleBookFinder } from '../service/GoogleBookFinder';
 import { Failure } from '../../pure/Failure';
 import { CustomResponse } from '../../pure/http/CustomResponse';

--- a/src/main/ts/booklet/impure/router/BookRouter.ts
+++ b/src/main/ts/booklet/impure/router/BookRouter.ts
@@ -1,4 +1,4 @@
-import { Http, Request, Response } from 'some-http-library';
+import { Http, Request, Response } from 'zhttp/http';
 import { BookHandler } from '../service/BookHandler';
 import { Failure } from '../../pure/Failure';
 import { CustomResponse } from '../../pure/http/CustomResponse';

--- a/src/main/ts/booklet/impure/router/ReadingRouter.ts
+++ b/src/main/ts/booklet/impure/router/ReadingRouter.ts
@@ -1,4 +1,4 @@
-import { Http, Request, Response } from 'some-http-library';
+import { Http, Request, Response } from 'zhttp/http';
 import { ReadingHandler } from '../service/ReadingHandler';
 import { Failure } from '../../pure/Failure';
 import { CustomResponse } from '../../pure/http/CustomResponse';


### PR DESCRIPTION
Enable the TypeScript build step and fix TypeScript errors.

* **GitHub Actions Workflow**
  - Uncomment lines related to running the TypeScript build and tests in `.github/workflows/ci.yaml`.

* **Main.ts**
  - Import `ConfigLive` from `./ConfigLive` instead of `./Config`.

* **Router Files**
  - Import `Http`, `Request`, and `Response` from `zhttp/http` instead of `some-http-library` in `BookFinderRouter.ts`, `BookRouter.ts`, and `ReadingRouter.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kchapl/booklet?shareId=XXXX-XXXX-XXXX-XXXX).